### PR TITLE
add @DeepCodeAI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![C++ CI](https://github.com/LucasLarson/HQ9/workflows/C++%20CI/badge.svg)](https://github.com/LucasLarson/HQ9/actions?query=workflow:"C%2B%2B+CI")
 [![Lint Code Base](https://github.com/LucasLarson/HQ9/workflows/Lint%20Code%20Base/badge.svg)](https://github.com/LucasLarson/HQ9/actions?query=workflow:"Lint+Code+Base")
 [![CodeQL analysis](https://github.com/LucasLarson/HQ9/workflows/CodeQL%20analysis/badge.svg)](https://github.com/LucasLarson/HQ9/actions?query=workflow:"CodeQL%20analysis")
+[![DeepCode](https://www.deepcode.ai/api/gh/badge?key=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwbGF0Zm9ybTEiOiJnaCIsIm93bmVyMSI6Ikx1Y2FzTGFyc29uIiwicmVwbzEiOiJIUTkiLCJpbmNsdWRlTGludCI6ZmFsc2UsImF1dGhvcklkIjoxNTg0MiwiaWF0IjoxNTk5NzU0OTk0fQ.2vnmnRClDJONlco1vdiqOJt7gNYiqnT9kyWxFZ_vFuw)](https://www.deepcode.ai/app/gh/LucasLarson/HQ9/_/dashboard)
 [![GPLP](https://img.shields.io/badge/license-GPLP-blue "GNU General Public License for Pedants")](https://github.com/LucasLarson/HQ9/blob/main/LICENSE.md)
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,7 +10,7 @@ printf 'platform set to %s\n' "$platform"
 printf 'beginning compilation...\n'
 
 # create C++20 executable for macOS, if not then for Linux
-if [[ Darwin = "$platform" ]]; then
+if [[ Darwin == "$platform" ]]; then
   clang++ -std=c++2a --verbose -Wall -Wextra -pedantic -g -integrated-as -lm \
     -lstdc++ -O0 -pthread -save-stats -save-temps -v -fcaret-diagnostics \
     -fdiagnostics-fixit-info -fdiagnostics-parseable-fixits \
@@ -18,7 +18,7 @@ if [[ Darwin = "$platform" ]]; then
     -fno-builtin -fshow-column -fshow-source-location -fstandalone-debug \
     -ftime-report main.cpp helloWorld.cpp beer.cpp -o "HQ9+"
 
-elif [[ "Linux" = "$platform" ]]; then
+elif [[ "Linux" == "$platform" ]]; then
   g++ --verbose -Wall -Wextra -pedantic -save-temps -v -fgnu-tm -lm -latomic \
     -lstdc++ -g -fgnat-encodings=all main.cpp helloWorld.cpp beer.cpp -o "HQ9+"
 


### PR DESCRIPTION
Add @DeepCodeAI badge to README.
On success it appears as
[![DeepCode](https://web.archive.org/web/20200910163116id_/deepcode.ai/api/gh/badge?key=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwbGF0Zm9ybTEiOiJnaCIsIm93bmVyMSI6Ikx1Y2FzTGFyc29uIiwicmVwbzEiOiJIUTkiLCJpbmNsdWRlTGludCI6ZmFsc2UsImF1dGhvcklkIjoxNTg0MiwiaWF0IjoxNTk5NzU0OTk0fQ.2vnmnRClDJONlco1vdiqOJt7gNYiqnT9kyWxFZ_vFuw)](https://www.deepcode.ai/app/gh/LucasLarson/HQ9/_/dashboard)
Image and status cached via @InternetArchive.