### PR TITLE
add automated @Gitpod-io setup for virtual installation

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtimes, etc.
+# For example "bastet", a command-line tetris clone:
+# RUN brew install bastet
+#
+# More information: https://www.gitpod.io/docs/config-docker/

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full@aad6c2650705
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
+---
 image:
   file: .gitpod.Dockerfile
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,5 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - init: cmake .

--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -37,9 +37,11 @@ excluded_words:
   - Crashlytics
   - csharp  # CodeQL Analysis
   - cyberciti  # cyberciti.biz
+  - esolangs
   - ffs
   - guillaumealgis  # guillaumealgis/XcodeWarningsAsXcconfig
   - ibiqlik  # ibiqlik/action-yamllint
+  - imgbotconfig  # dabutvin/Imgbot
   - jonreid  # jonreid/XcodeWarnings
   - LucasLarson
   - Mackup
@@ -111,7 +113,8 @@ excluded_words:
 
   # Git
   - gmv  # homemade alias to `git mv`
-  - gunstage
+  - gunstage  # `🔫  `git unstage` as a service https://git.io/gunstage
+  - lsi  # Jekyll’s latent semantic indexing
   - osxkeychain
   - unstage
   - unstagers
@@ -125,6 +128,11 @@ excluded_words:
   - Otechie
   - sarif  # OSSAR
 
+  # Gitpod
+  - bastet  # gitpod-io/gitpod
+  - runtimes
+  - tetris
+
   # JetBrains
   - iml
   - ipr
@@ -132,6 +140,9 @@ excluded_words:
   - mpeltonen
   - replstate
   - sbt-idea
+
+  # Linux
+  - nfs  # github/gitignore@4f7062e
 
   # macOS
   - donotpresent

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/LucasLarson/HQ9)
+
 # HQ9+
 
 [![CodeFactor](https://www.codefactor.io/repository/github/lucaslarson/hq9/badge)](https://www.codefactor.io/repository/github/lucaslarson/hq9)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/LucasLarson/HQ9)
-
 # HQ9+
 
 [![CodeFactor](https://www.codefactor.io/repository/github/lucaslarson/hq9/badge)](https://www.codefactor.io/repository/github/lucaslarson/hq9)
+[![Gitpod: ready to code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/LucasLarson/HQ9)
 [![Codeac](https://static.codeac.io/badges/2-274529532.svg "Codeac.io")](https://app.codeac.io/github/LucasLarson/HQ9)
 [![C++ CI](https://github.com/LucasLarson/HQ9/workflows/C++%20CI/badge.svg)](https://github.com/LucasLarson/HQ9/actions?query=workflow:"C%2B%2B+CI")
 [![Super-Linter](https://github.com/LucasLarson/HQ9/workflows/Super-Linter/badge.svg)](https://github.com/LucasLarson/HQ9/actions?query=workflow:"Super-Linter")


### PR DESCRIPTION
> This commit implements a fully-automated development setup using Gitpod.io, an online IDE for GitHub and GitLab that enables Dev-Environments-As-Code.
> This makes it easy for anyone to get a ready-to-code workspace for any branch, issue or pull request almost instantly with a single click.