### PR TITLE
repair Dockerfile digest string

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full@sha256:aad6c2650705
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full@aad6c2650705
+FROM gitpod/workspace-full
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:

--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -56,6 +56,7 @@ excluded_words:
 
   # AsciiDoc
   - adoc
+  - toclevels
 
   # CSS
   - webtv


### PR DESCRIPTION
undoes 0ff546761503404b1e558e3f17a0c70a0af2c2d5, which intended to implement best practices by avoiding the default latest release