### PR TITLE
remove `docker` URI scheme from Super-Linter configuration

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -44,7 +44,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v3.11.0
+        uses: github/super-linter@v3.12.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -44,7 +44,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3.11.0
+        uses: github/super-linter@v3.11.0
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main


### PR DESCRIPTION
Super-Linter’s [readme no longer recommends](https://github.com/github/super-linter/commit/0744055595da9908dff217b26640f8db016ec764):
```
docker://github/super-linter:v𝑛
```
they now say to use:
```
         github/super-linter@v𝑛
```
where 𝑛 is any integer in ℝ whose value is 3.