### PR TITLE
add mandatory `make` to Gitpod `cmake .` recipe to build

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,4 +3,4 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: cmake .
+  - init: cmake . && make


### PR DESCRIPTION
[Gitpod’s out-of-the-box configuration](https://github.com/LucasLarson/HQ9/blob/680faff2b0881cdfa5288f6502ffa19f2cf80d8a/.gitpod.yml) includes only `cmake .`, which isn’t sufficient to build the software. If CMake is successful, it must be followed by `make` with no arguments.