### PR TITLE
add § strategy to CodeQL workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,6 +1,6 @@
 ---
 name: Autofix
-"on":
+on:
   push:
     # Only targets develop branch to avoid amplification effects of auto-fixing
     # the exact same stuff in multiple non-rebased branches.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,6 +16,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java',
+        # 'javascript', 'python']
+        # https://git.io/overriding-automatic-language-detection
+        language: 'cpp'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.3

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -16,7 +16,7 @@ name: Super-Linter
 #############################
 on:
   push:
-    branches-ignore:  # [main]
+    branches-ignore: [main]
   pull_request:
     branches:  # [main]
 

--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -43,14 +43,17 @@ excluded_words:
   - ibiqlik  # ibiqlik/action-yamllint
   - imgbotconfig  # dabutvin/Imgbot
   - jonreid  # jonreid/XcodeWarnings
+  - ksh  # Korn shell
   - LucasLarson
   - Mackup
+  - minutiæ  # performatively pedantic minutiae
   - nixCraft  # Vivek Gite, cyberciti.biz
   - noninfringement  # GNU General Public License
   - omz  # ohmyzsh
   - peter-evans  # peter-evans/create-pull-request
   - rustup
   - sobolevn  # sobolevn/misspell-fixer-action
+  - timey  # git --version < 2.23 is old-timey
   - typoci
   - uncommenting
   - VivekGite  # nixCraft, cyberciti.biz
@@ -224,6 +227,7 @@ excluded_words:
   - zdharma
   - zrecompile
   - zsdoc
+  - zsh
   - zshelldoc
   - Zunit
   - zwc


### PR DESCRIPTION
with `fail-fast: false` and `language: 'cpp'`