### PR TITLE
Super-Linter chokes without full repository history

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -36,6 +36,9 @@ jobs:
       ##########################
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          # linter requires full repository history
+          fetch-depth: 0
 
       ################################
       # Run Linter against code base #


### PR DESCRIPTION
Opaque, but

> Full git history is needed to get a proper list of changed files within `super-linter`

— https://github.com/github/super-linter/commit/56b32c3