### PR TITLE
upgrade CodeQL analysis to better emulate template

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,9 +3,8 @@ name: "CodeQL Analysis"
 
 on:
   push:
-    branches:
   pull_request:
-    # The branches below must be a subset of the branches above
+    # The branches below must be a subset of the `push:` branches above, if any
     branches:
   schedule:
     #        ┌────────── minute (0 - 59)
@@ -13,28 +12,19 @@ on:
     #        │  │ ┌───── day of the month (1 - 31)
     #        │  │ │ ┌─── month (1 - 12 or JAN-DEC)
     #        │  │ │ │ ┌─ day of the week (0 - 6 or SUN-SAT)
-    - cron: '0 21 * * 2'
-    # Tuesday at 9pm UTC
+    - cron: '30 1 * * 0'
+    # Sunday at 1:30am UTC
 
 jobs:
   CodeQL-Build:
-
+    # CodeQL runs on `ubuntu-latest`, `windows-latest`, and `macos-latest`
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.3.4
-        with:
-          # We must fetch at least the immediate parents so that if this is
-          # a pull request then we can checkout the head.
-          fetch-depth: 2
+        uses: actions/checkout@v2
 
-      # If this run was triggered by a pull request event, then checkout
-      # the head of the pull request instead of the merge commit.
-      - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}
-
-      # Initializes the CodeQL tools for scanning.
+      # Initialize the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         # Override language selection by uncommenting this and choosing


### PR DESCRIPTION
In response to:
- Error:
> Workflows triggered by Dependabot on the `push` event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the `pull_request` event for this workflow and avoid triggering on the `push` event for Dependabot branches. See https://git.io/scanning-on-push for more information on how to configure these events.
- Warning:
> `git checkout HEAD^2` is no longer necessary. Please remove this step as Code Scanning recommends analyzing the merge commit for best results.

---
Template: https://github.com/github/codeql-action/tree/ea5ae18#usage