### PR TITLE
remove `git.io` links (fix #136)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,6 @@
 ---
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://git.io/help-dependabot-configuration
-# https://github.com/dependabot/dependabot-core/issues/2219#issuecomment-829501674
 
 version: 2
 updates:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,16 +38,5 @@ jobs:
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2
 
-      # ℹ️  Command-line programs to run using the OS shell.
-      # 📚 https://git.io/workflow-syntax-for-github-actions
-
-      # ✏️  If the Autobuild fails above, remove it and uncomment the
-      #    following three lines and modify them (or add more) to build your
-      #    code if your project uses a compiled language
-
-      # - run: |
-      #    make bootstrap
-      #    make release
-
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/beer.cpp
+++ b/beer.cpp
@@ -4,7 +4,7 @@
 
   Lucas Larson
   copyright GPL v3.0+
-  https://git.io/HQ9+
+  https://github.com/LucasLarson/HQ9
 
 */
 

--- a/beer.hpp
+++ b/beer.hpp
@@ -4,7 +4,7 @@
 
   Lucas Larson
   copyright GPL v3.0+
-  https://git.io/HQ9+
+  https://github.com/LucasLarson/HQ9
 
 */
 

--- a/helloWorld.cpp
+++ b/helloWorld.cpp
@@ -4,7 +4,7 @@
 
   Lucas Larson
   copyright GPL v3.0+
-  https://git.io/HQ9+
+  https://github.com/LucasLarson/HQ9
 
 */
 

--- a/helloWorld.hpp
+++ b/helloWorld.hpp
@@ -4,7 +4,7 @@
 
   Lucas Larson
   copyright GPL v3.0+
-  https://git.io/HQ9+
+  https://github.com/LucasLarson/HQ9
 
 */
 

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,7 @@
 
   Lucas Larson
   copyright GPL v3.0+
-  https://git.io/HQ9+
+  https://github.com/LucasLarson/HQ9
 
 */
 


### PR DESCRIPTION
@GitHub ends 11 years of serving `git.io` redirections on 2022-04-29[^1] after providing 3 days warning. This Pull Request™ removes affected content to fix #136.

[^1]: [github.blog/changelog/2022-04-25-git-io-deprecation](https://github.blog/changelog/2022-04-25-git-io-deprecation/)