### PR TITLE
search the executable rather than checking its output (#162)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -44,9 +44,8 @@ fi
 # succeed only if author’s name appears within 3 seconds of opening it
 printf 'Checking the executable%ss output...\n\n' "’"
 
-# portable substring search of the program’s output
-# https://stackoverflow.com/a/21115356
-if timeout 3 "./${program}" 2>&1 | grep -q "${author}"; then
+# ensure the executable contains the author’s name as a heuristic
+if grep -q "${author}" "./${program}"; then
   printf '%s  %s interpreter bootstrapping succeeded.\n\n' "✅" "${program}"
   printf 'Activate it by entering: ./%s\n' "${program}"
   printf 'then press return.\n\n\n'


### PR DESCRIPTION
- it’s faster and safer to `grep $program` than to run the new executable¹ to fix #162
- `timeout` is not a POSIX-specified utility² or special built‑in³

---
1. https://github.com/LucasLarson/HQ9/blob/03585e61206210c1d0536471b15cf056ca6eb874/bootstrap.sh#L49-L53
2. [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/idx/utilities.html)
3. [POSIX special built-in utilities](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/idx/sbi.html)