### PR TITLE
repair broken Replit badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CodeFactor](https://www.codefactor.io/repository/github/lucaslarson/hq9/badge)](https://www.codefactor.io/repository/github/lucaslarson/hq9)
 [![Gitpod: ready to code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/LucasLarson/HQ9)
-[![Run on Repl.it](https://github.com/replit/replit.github.io/raw/8d6b0eaf1c/static/images/repls/run-on-replit.svg)](https://repl.it/github/LucasLarson/HQ9)
+[![Run on Repl.it](https://web.archive.org/web/0id_/github.com/replit/replit.github.io/raw/8d6b0eaf1c/static/images/repls/run-on-replit.svg)](https://repl.it/github/LucasLarson/HQ9)
 [![Google: ready to build](https://img.shields.io/badge/Google%20Cloud%20Shell-build-5391fe?logo=google-cloud&logoColor=fff)](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/LucasLarson/HQ9)
 [![Codeac](https://static.codeac.io/badges/2-274529532.svg "Codeac.io")](https://app.codeac.io/github/LucasLarson/HQ9)
 [![C++ CI](https://github.com/LucasLarson/HQ9/workflows/C++%20CI/badge.svg)](https://github.com/LucasLarson/HQ9/actions?query=workflow:"C%2B%2B+CI")


### PR DESCRIPTION
Replit’s `replit.github.io` repository’s no longer accessible; this commit restores an image using the Wayback Machine to fix #179 (related: #142, #143).