### PR TITLE
remove `push` trigger from CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,6 @@
 name: "CodeQL Analysis"
 
 on:
-  push:
   pull_request:
 
   schedule:


### PR DESCRIPTION
Because Dependabot [disprefer](https://en.wiktionary.org/?curid=1414959#English)s [triggers on `push` events](https://github.com/github/codeql-action/blob/2f93805cef/src/actions-util.ts#L633-L636):

> Workflows triggered by Dependabot on the `push` event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the `pull_request` event for this workflow and avoid triggering on the `push` event for Dependabot branches. See https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push for more information on how to configure these events.