### PR TITLE
remove license-check badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![Super-Linter](https://github.com/LucasLarson/HQ9/workflows/Super-Linter/badge.svg)](https://github.com/LucasLarson/HQ9/actions?query=workflow:"Super-Linter")
 [![CodeQL analysis](https://github.com/LucasLarson/HQ9/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/LucasLarson/HQ9/actions/workflows/codeql-analysis.yml)
 [![GPLP](https://img.shields.io/badge/license-GPLP-blue "GNU General Public License for Pedants")](https://github.com/LucasLarson/HQ9/blob/main/license.adoc)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FLucasLarson%2FHQ9.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FLucasLarson%2FHQ9?ref=badge_shield)
 <!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
 
 - [Build](#build)


### PR DESCRIPTION
A repository with non-standard licensing is not a good candidate for license checking:

- [x] remove the badge
- [x] fix #198
- [x] undo #19