### PR TITLE
fix: set CodeQL `security-events` permissions to `write`

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  security-events: write
 
 jobs:
   CodeQL-Build:


### PR DESCRIPTION
[github/codeql-action@`c709994d279`#permissions](https://github.com/github/codeql-action/tree/c709994d279#permissions):
> All advanced setup Code Scanning workflows must have the `security-events: write` permission.

## Summary by Sourcery

Bug Fixes:
- Enable the required `security-events: write` permission for advanced CodeQL setup